### PR TITLE
feat: add identity pre-verification example

### DIFF
--- a/identity-pre-verification/kickstart.json
+++ b/identity-pre-verification/kickstart.json
@@ -1,4 +1,5 @@
 {
+  "licenseId": "REPLACE_LICENSE_KEY",
   "variables": {
     "allowedOrigin": "http://localhost:4200",
     "authorizedRedirectURL": "http://localhost:4200",
@@ -8,13 +9,15 @@
     "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
     "apiKey": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works",
     "asymmetricKeyId": "#{UUID()}",
-    "newThemeId": "#{UUID()}",
     "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
     "adminEmail": "admin@example.com",
     "adminPassword": "password",
     "userEmail": "richard@example.com",
     "userPassword": "password",
-    "userUserId": "00000000-0000-0000-0000-111111111111"
+    "userUserId": "00000000-0000-0000-0000-111111111111",
+    "emailVerificationFormId": "#{UUID()}",
+    "emailFieldId": "#{UUID()}",
+    "passwordFieldId": "#{UUID()}"
   },
   "apiKeys": [
     {
@@ -321,7 +324,7 @@
     },
     {
       "method": "PATCH",
-      "url": "api/system-configuration",
+      "url": "/api/system-configuration",
       "body": {
         "systemConfiguration": {
           "corsConfiguration": {
@@ -366,8 +369,64 @@
           "emailConfiguration": {
             "defaultFromEmail": "no-reply@example.com",
             "host": "mailpit",
-            "port": 1025
+            "port": 1025,
+            "unverified": {
+              "behavior": "Gated"
+            },
+            "verifyEmail": true,
+            "verificationEmailTemplateId": "7fa81426-42a9-4eb2-ac09-73c044d410b1"
           }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/form/field/#{emailFieldId}",
+      "body": {
+        "field": {
+          "name": "Email Verification - Email Address",
+          "key": "user.email",
+          "type": "email",
+          "required": true,
+          "control": "text"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/form/field/#{passwordFieldId}",
+      "body": {
+        "field": {
+          "name": "Email Verification - Password",
+          "key": "user.password",
+          "type": "string",
+          "required": true,
+          "control": "password"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/form/#{emailVerificationFormId}",
+      "body": {
+        "form": {
+          "name": "Email Verification",
+          "steps": [
+            {
+              "fields": [
+                "#{emailFieldId}"
+              ]
+            },
+            {
+              "type": "verifyEmail"
+            },
+            {
+              "fields": [
+                "#{passwordFieldId}"
+              ]
+            }
+          ],
+          "type": "registration"
         }
       }
     },
@@ -402,7 +461,10 @@
             "idTokenKeyId": "#{asymmetricKeyId}"
           },
           "registrationConfiguration": {
-            "enabled": true
+            "enabled": true,
+            "formId": "#{emailVerificationFormId}",
+            "type": "advanced",
+            "loginIdType": "email"
           }
         }
       }
@@ -420,15 +482,6 @@
         },
         "registration": {
           "applicationId": "#{applicationId}"
-        }
-      }
-    },
-    {
-      "method": "PATCH",
-      "url": "/api/tenant/#{defaultTenantId}",
-      "body": {
-        "tenant": {
-          "themeId": "#{newThemeId}"
         }
       }
     }

--- a/identity-pre-verification/kickstart.json
+++ b/identity-pre-verification/kickstart.json
@@ -323,28 +323,6 @@
       }
     },
     {
-      "method": "PATCH",
-      "url": "/api/system-configuration",
-      "body": {
-        "systemConfiguration": {
-          "corsConfiguration": {
-            "allowCredentials": true,
-            "allowedMethods": [
-              "GET",
-              "POST",
-              "OPTIONS"
-            ],
-            "allowedOrigins": [
-              "#{allowedOrigin}"
-            ],
-            "debug": false,
-            "enabled": true,
-            "preflightMaxAgeInSeconds": 0
-          }
-        }
-      }
-    },
-    {
       "method": "POST",
       "url": "/api/user/registration",
       "body": {
@@ -386,7 +364,7 @@
       "url": "/api/form/field/#{emailFieldId}",
       "body": {
         "field": {
-          "name": "Email Verification - Email Address",
+          "name": "Email Identity Pre-Verification - Email Address",
           "key": "user.email",
           "type": "email",
           "required": true,
@@ -399,7 +377,7 @@
       "url": "/api/form/field/#{passwordFieldId}",
       "body": {
         "field": {
-          "name": "Email Verification - Password",
+          "name": "Email Identity Pre-Verification - Password",
           "key": "user.password",
           "type": "string",
           "required": true,
@@ -412,7 +390,7 @@
       "url": "/api/form/#{emailVerificationFormId}",
       "body": {
         "form": {
-          "name": "Email Verification",
+          "name": "Email Identity Pre-Verification",
           "steps": [
             {
               "fields": [
@@ -438,7 +416,7 @@
       "tenantId": "#{defaultTenantId}",
       "body": {
         "application": {
-          "name": "Example app",
+          "name": "Example Application - Identity Pre-Verification",
           "oauthConfiguration": {
             "authorizedRedirectURLs": [
               "#{authorizedPostLogoutURL}",

--- a/identity-pre-verification/kickstart.json
+++ b/identity-pre-verification/kickstart.json
@@ -1,0 +1,436 @@
+{
+  "variables": {
+    "allowedOrigin": "http://localhost:4200",
+    "authorizedRedirectURL": "http://localhost:4200",
+    "authorizedPostLogoutURL": "http://localhost:4200/logged-out",
+    "authorizedOriginURL": "http://localhost:4200",
+    "logoutURL": "http://localhost:4200",
+    "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
+    "apiKey": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works",
+    "asymmetricKeyId": "#{UUID()}",
+    "newThemeId": "#{UUID()}",
+    "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
+    "adminEmail": "admin@example.com",
+    "adminPassword": "password",
+    "userEmail": "richard@example.com",
+    "userPassword": "password",
+    "userUserId": "00000000-0000-0000-0000-111111111111"
+  },
+  "apiKeys": [
+    {
+      "key": "#{apiKey}",
+      "description": "Unrestricted API key"
+    }
+  ],
+  "requests": [
+    {
+      "method": "POST",
+      "url": "/api/email/template/0502df1e-4010-4b43-b571-d423fce978b2",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Reset your password",
+          "defaultHtmlTemplate": "@{templates/email/change-password.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/change-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Forgot Password"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/e160cc59-a73e-4d95-8287-f82e5c541a5c",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Setup your password",
+          "defaultHtmlTemplate": "@{templates/email/setup-password.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/setup-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Setup Password"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/7fa81426-42a9-4eb2-ac09-73c044d410b1",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Verify your FusionAuth email address",
+          "defaultHtmlTemplate": "@{templates/email/email-verification.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/email-verification.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Email Verification"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/c16b65a5-e6e9-4499-a7ac-ae228f8d9864",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Verify your Registration",
+          "defaultHtmlTemplate": "@{templates/email/registration-verification.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/registration-verification.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Registration Verification"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/8e1d6af1-dcda-41d9-85fb-48a1376d4e29",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Create your parental account",
+          "defaultHtmlTemplate": "@{templates/email/parent-registration.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/parent-registration.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Parent Registration"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/fa6668cb-8569-44df-b0a2-8fcd996df915",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Log into FusionAuth",
+          "defaultHtmlTemplate": "@{templates/email/passwordless-login.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/passwordless-login.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Passwordless Login"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/e3da3003-972f-4a02-8c7e-dae6455a6478",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Confirm your child's account",
+          "defaultHtmlTemplate": "@{templates/email/confirm-child.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/confirm-child.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Confirm Child Account"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/162b3719-3d71-4638-b9bf-f3e2093f7fe1",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Notice of your consent",
+          "defaultHtmlTemplate": "@{templates/email/coppa-notice.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/coppa-notice.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "COPPA Notice"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/f0e9d738-c98d-45ee-b869-8636342c5158",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Reminder: Notice of your consent",
+          "defaultHtmlTemplate": "@{templates/email/coppa-email-plus-notice.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/coppa-email-plus-notice.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "COPPA Notice Reminder"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/e6c74b53-d43d-471e-ae7e-906456d0f341",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Your password is not secure",
+          "defaultHtmlTemplate": "@{templates/email/breached-password.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/breached-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Breached Password Notification"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/68349684-10b7-453d-805b-6b81d8ef6f6f",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Threat Detected",
+          "defaultHtmlTemplate": "@{templates/email/threat-detected.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/threat-detected.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Threat Detected"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/481ea459-6aa8-4ada-badd-605c6dcda709",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Your second factor code",
+          "defaultHtmlTemplate": "@{templates/email/two-factor-login.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/two-factor-login.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Two Factor Authentication"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/0c4aa5f1-565e-4113-8b8e-8b58e7ef403b",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "A second factor was added",
+          "defaultHtmlTemplate": "@{templates/email/two-factor-add.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/two-factor-add.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Two Factor Authentication Method Added"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/email/template/01e21c7b-e293-4e45-9de5-96dec4a92a0b",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "A second factor was removed",
+          "defaultHtmlTemplate": "@{templates/email/two-factor-remove.html.ftl}",
+          "defaultTextTemplate": "@{templates/email/two-factor-remove.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Two Factor Authentication Method Removed"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/5a1f0b4e-3d2c-4a19-8e7f-12a34b56c789",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-forgot-password.txt.ftl}",
+          "name": "Forgot Password",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/6b2e1c5d-4f3a-4b28-9f8e-23b45c67d890",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-passwordless-login.txt.ftl}",
+          "name": "Passwordless Login",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/7c3d2e6f-5a4b-4c37-af9d-34c56d78e901",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-setup-password.txt.ftl}",
+          "name": "Setup Password",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/8d4e3f70-6b5c-4d46-bfae-45d67e89f012",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-two-factor-login.txt.ftl}",
+          "name": "Two Factor Authentication",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/9e5f4081-7c6d-4e55-c0bf-56e78f9a0123",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-two-factor-add.txt.ftl}",
+          "name": "Two Factor Authentication Method Added",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/af607192-8d7e-4f64-d1c0-67f890ab1234",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-two-factor-remove.txt.ftl}",
+          "name": "Two Factor Authentication Method Removed",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/b07182a3-9e8f-4073-e2d1-78f90abc2345",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-threat-detected.txt.ftl}",
+          "name": "Threat Detected",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/message/template/c18293b4-af90-4162-f3e2-89f0abcd3456",
+      "body": {
+        "messageTemplate": {
+          "defaultTemplate": "@{templates/message/phone-verification.txt.ftl}",
+          "name": "Phone Verification",
+          "type": "SMS"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/key/generate/#{asymmetricKeyId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "key": {
+          "algorithm": "RS256",
+          "name": "For exampleapp",
+          "length": 2048
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "api/system-configuration",
+      "body": {
+        "systemConfiguration": {
+          "corsConfiguration": {
+            "allowCredentials": true,
+            "allowedMethods": [
+              "GET",
+              "POST",
+              "OPTIONS"
+            ],
+            "allowedOrigins": [
+              "#{allowedOrigin}"
+            ],
+            "debug": false,
+            "enabled": true,
+            "preflightMaxAgeInSeconds": 0
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration",
+      "body": {
+        "user": {
+          "email": "#{adminEmail}",
+          "password": "#{adminPassword}"
+        },
+        "registration": {
+          "applicationId": "#{FUSIONAUTH_APPLICATION_ID}",
+          "roles": [
+            "admin"
+          ]
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "issuer": "http://localhost:9011",
+          "emailConfiguration": {
+            "defaultFromEmail": "no-reply@example.com",
+            "host": "mailpit",
+            "port": 1025
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/application/#{applicationId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "application": {
+          "name": "Example app",
+          "oauthConfiguration": {
+            "authorizedRedirectURLs": [
+              "#{authorizedPostLogoutURL}",
+              "#{authorizedRedirectURL}"
+            ],
+            "authorizedOriginURLs": [
+              "#{authorizedOriginURL}"
+            ],
+            "clientSecret": "super-secret-secret-that-should-be-regenerated-for-production",
+            "logoutURL": "#{logoutURL}",
+            "enabledGrants": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "debug": true,
+            "generateRefreshTokens": true,
+            "requireRegistration": true
+          },
+          "jwtConfiguration": {
+            "enabled": true,
+            "accessTokenKeyId": "#{asymmetricKeyId}",
+            "idTokenKeyId": "#{asymmetricKeyId}"
+          },
+          "registrationConfiguration": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/#{userUserId}",
+      "body": {
+        "user": {
+          "birthDate": "1985-11-23",
+          "email": "#{userEmail}",
+          "firstName": "Richard",
+          "lastName": "Hendricks",
+          "password": "#{userPassword}"
+        },
+        "registration": {
+          "applicationId": "#{applicationId}"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "themeId": "#{newThemeId}"
+        }
+      }
+    }
+  ]
+}

--- a/identity-pre-verification/kickstart.json
+++ b/identity-pre-verification/kickstart.json
@@ -371,9 +371,11 @@
             "host": "mailpit",
             "port": 1025,
             "unverified": {
-              "behavior": "Gated"
+              "behavior": "Gated",
+              "allowEmailChangeWhenGated": true
             },
             "verifyEmail": true,
+            "verifyEmailWhenChanged": true,
             "verificationEmailTemplateId": "7fa81426-42a9-4eb2-ac09-73c044d410b1"
           }
         }
@@ -482,7 +484,8 @@
         },
         "registration": {
           "applicationId": "#{applicationId}"
-        }
+        },
+        "skipVerification": true
       }
     }
   ]

--- a/identity-pre-verification/kickstart.json
+++ b/identity-pre-verification/kickstart.json
@@ -364,7 +364,7 @@
       "url": "/api/form/field/#{emailFieldId}",
       "body": {
         "field": {
-          "name": "Email Identity Pre-Verification - Email Address",
+          "name": "Identity Pre-Verification - Email Address Field Example",
           "key": "user.email",
           "type": "email",
           "required": true,
@@ -377,7 +377,7 @@
       "url": "/api/form/field/#{passwordFieldId}",
       "body": {
         "field": {
-          "name": "Email Identity Pre-Verification - Password",
+          "name": "Identity Pre-Verification - Password Field Example",
           "key": "user.password",
           "type": "string",
           "required": true,
@@ -390,7 +390,7 @@
       "url": "/api/form/#{emailVerificationFormId}",
       "body": {
         "form": {
-          "name": "Email Identity Pre-Verification",
+          "name": "Identity Pre-Verification - Email Form Example",
           "steps": [
             {
               "fields": [
@@ -416,7 +416,7 @@
       "tenantId": "#{defaultTenantId}",
       "body": {
         "application": {
-          "name": "Example Application - Identity Pre-Verification",
+          "name": "Identity Pre-Verification - Application Example",
           "oauthConfiguration": {
             "authorizedRedirectURLs": [
               "#{authorizedPostLogoutURL}",

--- a/identity-pre-verification/templates/email/breached-password.html.ftl
+++ b/identity-pre-verification/templates/email/breached-password.html.ftl
@@ -1,0 +1,12 @@
+[#setting url_escaping_charset="UTF-8"]
+<p>This password was found in the list of vulnerable passwords, and is no longer secure.</p>
+
+<p>In order to secure your account, it is recommended to change your password at your earliest convenience.</p>
+
+<p>Follow this link to change your password.</p>
+
+<a href="http://localhost:9011/password/forgot?client_id=${(application.oauthConfiguration.clientId)!''}&email=${user.email?url}&tenantId=${user.tenantId}">
+  http://localhost:9011/password/forgot?client_id=${(application.oauthConfiguration.clientId)!''}&email=${user.email?url}&tenantId=${user.tenantId}
+</a>
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/breached-password.txt.ftl
+++ b/identity-pre-verification/templates/email/breached-password.txt.ftl
@@ -1,0 +1,12 @@
+[#setting url_escaping_charset="UTF-8"]
+This password was found in the list of vulnerable passwords, and is no longer secure.
+
+In order to secure your account, it is recommended to change your password at your earliest convenience.
+
+Follow this link to change your password.
+
+http://localhost:9011/password/forgot?client_id=${(application.oauthConfiguration.clientId)!''}&email=${user.email?url}&tenantId=${user.tenantId}
+
+- FusionAuth Admin
+
+

--- a/identity-pre-verification/templates/email/change-password.html.ftl
+++ b/identity-pre-verification/templates/email/change-password.html.ftl
@@ -1,0 +1,11 @@
+[#setting url_escaping_charset="UTF-8"]
+To change your password click on the following link.
+<p>
+  [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state'.
+       If we have an application context, append the client_id to ensure the correct application theme when applicable.
+  --]
+  [#assign url = "http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}" /]
+  [#list state!{} as key, value][#if key != "tenantId" && key != "client_id" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+  <a href="${url}">${url}</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/change-password.txt.ftl
+++ b/identity-pre-verification/templates/email/change-password.txt.ftl
@@ -1,0 +1,12 @@
+[#setting url_escaping_charset="UTF-8"]
+To change your password click on the following link.
+
+  [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state'.
+       If we have an application context, append the client_id to ensure the correct application theme when applicable.
+  --]
+[#assign url = "http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}" /]
+[#list state!{} as key, value][#if key != "tenantId" && key != "client_id" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+${url}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/confirm-child.html.ftl
+++ b/identity-pre-verification/templates/email/confirm-child.html.ftl
@@ -1,0 +1,5 @@
+Your child has created an account with us and you need to confirm them before they are added to your family. Click the link below to confirm your child's account.
+<p>
+  <a href="http://example.com/family/confirm-child">http://example.com/family/confirm-child</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/confirm-child.txt.ftl
+++ b/identity-pre-verification/templates/email/confirm-child.txt.ftl
@@ -1,0 +1,5 @@
+Your child has created an account with us and you need to confirm them before they are added to your family. Click the link below to confirm your child's account.
+
+http://example.com/family/confirm-child
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/coppa-email-plus-notice.html.ftl
+++ b/identity-pre-verification/templates/email/coppa-email-plus-notice.html.ftl
@@ -1,0 +1,5 @@
+A while ago, you granted your child consent in our system. This email is a second notice of this consent as required by law and also to remind to that you can revoke this consent at anytime on our website or by clicking the link below:
+<p>
+  <a href="http://example.com/consent/manage">http://example.com/consent/manage</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/coppa-email-plus-notice.txt.ftl
+++ b/identity-pre-verification/templates/email/coppa-email-plus-notice.txt.ftl
@@ -1,0 +1,5 @@
+A while ago, you granted your child consent in our system. This email is a second notice of this consent as required by law and also to remind to that you can revoke this consent at anytime on our website or by clicking the link below:
+
+http://example.com/consent/manage
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/coppa-notice.html.ftl
+++ b/identity-pre-verification/templates/email/coppa-notice.html.ftl
@@ -1,0 +1,5 @@
+You recently granted your child consent in our system. This email is to notify you of this consent. If you did not grant this consent or wish to revoke this consent, click the link below:
+<p>
+  <a href="http://example.com/consent/manage">http://example.com/consent/manage</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/coppa-notice.txt.ftl
+++ b/identity-pre-verification/templates/email/coppa-notice.txt.ftl
@@ -1,0 +1,5 @@
+You recently granted your child consent in our system. This email is to notify you of this consent. If you did not grant this consent or wish to revoke this consent, click the link below:
+
+http://example.com/consent/manage
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/email-verification.html.ftl
+++ b/identity-pre-verification/templates/email/email-verification.html.ftl
@@ -11,8 +11,8 @@ Pro tip, your email has already been verified, but feel free to complete the ver
 [#else]
 To complete your email verification click on the following link.
 <p>
-  <a href="http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}">
-    http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+  <a href="http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${tenant.id}">
+    http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${tenant.id}
   </a>
 </p>
 [/#if]

--- a/identity-pre-verification/templates/email/email-verification.html.ftl
+++ b/identity-pre-verification/templates/email/email-verification.html.ftl
@@ -1,0 +1,20 @@
+[#if user.verified]
+Pro tip, your email has already been verified, but feel free to complete the verification process to verify your verification of your email address.
+[/#if]
+
+[#-- When a one-time code is provided, you will want the user to enter this value interactively using a form. In this workflow the verificationId
+     is not shown to the user and instead the one-time code must be paired with the verificationId which is usually in a hidden form field. When the two
+     values are presented together, the email address can be verified --]
+[#if verificationOneTimeCode??]
+<p>To complete your email verification enter this code into the email verification form.</p>
+<p> ${verificationOneTimeCode} </p>
+[#else]
+To complete your email verification click on the following link.
+<p>
+  <a href="http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}">
+    http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+  </a>
+</p>
+[/#if]
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/email-verification.txt.ftl
+++ b/identity-pre-verification/templates/email/email-verification.txt.ftl
@@ -12,7 +12,7 @@ ${verificationOneTimeCode}
 [#else]
 To complete your email verification click on the following link.
 
-http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${tenant.id}
 [/#if]
 
 - FusionAuth Admin

--- a/identity-pre-verification/templates/email/email-verification.txt.ftl
+++ b/identity-pre-verification/templates/email/email-verification.txt.ftl
@@ -1,0 +1,18 @@
+[#if user.verified]
+Pro tip, your email has already been verified, but feel free to complete the verification process to verify your verification of your email address.
+[/#if]
+
+[#-- When a one-time code is provided, you will want the user to enter this value interactively using a form. In this workflow the verificationId
+     is not shown to the user and instead the one-time code must be paired with the verificationId which is usually in a hidden form field. When the two
+     values are presented together, the email address can be verified --]
+[#if verificationOneTimeCode??]
+To complete your email verification enter this code into the email verification form.
+
+${verificationOneTimeCode}
+[#else]
+To complete your email verification click on the following link.
+
+http://localhost:9011/email/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+[/#if]
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/parent-registration.html.ftl
+++ b/identity-pre-verification/templates/email/parent-registration.html.ftl
@@ -1,0 +1,5 @@
+Your child has created an account with us and needs you to create an account and verify them. You can sign up using the link below:
+<p>
+  <a href="http://example.com/family/confirm-child">http://example.com/family/confirm-child</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/parent-registration.txt.ftl
+++ b/identity-pre-verification/templates/email/parent-registration.txt.ftl
@@ -1,0 +1,5 @@
+Your child has created an account with us and needs you to create an account and verify them. You can sign up using the link below:
+
+http://example.com/family/confirm-child
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/passwordless-login.html.ftl
+++ b/identity-pre-verification/templates/email/passwordless-login.html.ftl
@@ -1,0 +1,9 @@
+[#setting url_escaping_charset="UTF-8"]
+You have requested to log into FusionAuth using this email address. If you do not recognize this request please ignore this email.
+<p>
+  [#-- The optional 'state' map provided on the Start Passwordless API call is exposed in the template as 'state' --]
+  [#assign url = "http://localhost:9011/oauth2/passwordless/${code}?tenantId=${user.tenantId}" /]
+  [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+  <a href="${url}">${url}</a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/passwordless-login.txt.ftl
+++ b/identity-pre-verification/templates/email/passwordless-login.txt.ftl
@@ -1,0 +1,10 @@
+[#setting url_escaping_charset="UTF-8"]
+You have requested to log into FusionAuth using this email address. If you do not recognize this request please ignore this email.
+
+[#-- The optional 'state' map provided on the Start Passwordless API call is exposed in the template as 'state' --]
+[#assign url = "http://localhost:9011/oauth2/passwordless/${code}?tenantId=${user.tenantId}" /]
+[#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+${url}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/registration-verification.html.ftl
+++ b/identity-pre-verification/templates/email/registration-verification.html.ftl
@@ -1,0 +1,20 @@
+[#if registration.verified]
+Pro tip, your registration has already been verified, but feel free to complete the verification process to verify your verification of your registration.
+[/#if]
+
+[#-- When a one-time code is provided, you will want the user to enter this value interactively using a form. In this workflow the verificationId
+     is not shown to the user and instead the one-time code must be paired with the verificationId which is usually in a hidden form field. When the two
+     values are presented together, the registration can be verified --]
+[#if verificationOneTimeCode??]
+<p>To complete your registration verification enter this code into the registration verification form.</p>
+<p> ${verificationOneTimeCode} </p>
+[#else]
+To complete your registration verification click on the following link.
+<p>
+  <a href="http://localhost:9011/registration/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}">
+    http://localhost:9011/registration/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+  </a>
+</p>
+[/#if]
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/registration-verification.txt.ftl
+++ b/identity-pre-verification/templates/email/registration-verification.txt.ftl
@@ -1,0 +1,18 @@
+[#if registration.verified]
+Pro tip, your registration has already been verified, but feel free to complete the verification process to verify your verification of your registration.
+[/#if]
+
+[#-- When a one-time code is provided, you will want the user to enter this value interactively using a form. In this workflow the verificationId
+     is not shown to the user and instead the one-time code must be paired with the verificationId which is usually in a hidden form field. When the two
+     values are presented together, the registration can be verified --]
+[#if verificationOneTimeCode??]
+To complete your registration verification enter this code into the registration verification form.
+
+${verificationOneTimeCode}
+[#else]
+To complete your registration verification click on the following link.
+
+http://localhost:9011/registration/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+[/#if]
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/setup-password.html.ftl
+++ b/identity-pre-verification/templates/email/setup-password.html.ftl
@@ -1,0 +1,7 @@
+Your account has been created and you must set up a password. Click on the following link to set up your password.
+<p>
+  <a href="http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}">
+    http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+  </a>
+</p>
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/setup-password.txt.ftl
+++ b/identity-pre-verification/templates/email/setup-password.txt.ftl
@@ -1,0 +1,5 @@
+Your account has been created and you must set up a password. Click on the following link to set up your password.
+
+http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/threat-detected.html.ftl
+++ b/identity-pre-verification/templates/email/threat-detected.html.ftl
@@ -1,0 +1,28 @@
+[#-- @ftlvariable name="event" type="io.fusionauth.domain.event.UserLoginSuspiciousEvent" --]
+[#setting url_escaping_charset="UTF-8"]
+[#if event.type == "UserLoginSuspicious"]
+  <p>A suspicious login was made on your account. If this was you, you can safely ignore this email. If this wasn't you, we recommend that you change your password as soon as possible.</p>
+[#elseif event.type == "UserLoginNewDevice"]
+  <p>A login from a new device was detected on your account. If this was you, you can safely ignore this email. If this wasn't you, we recommend that you change your password as soon as possible.</p>
+[#else]
+  <p>Suspicious activity has been observed on your account. In order to secure your account, it is recommended to change your password at your earliest convenience.</p>
+[/#if]
+
+<p>Device details</p>
+<ul>
+  <li><strong>Device name:</strong> ${(event.info.deviceName)!'&mdash;'}</li>
+  <li><strong>Device description:</strong> ${(event.info.deviceDescription)!'&mdash;'}</li>
+  <li><strong>Device type:</strong> ${(event.info.deviceType)!'&mdash;'}</li>
+  <li><strong>User agent:</strong> ${(event.info.userAgent)!'&mdash;'}</li>
+</ul>
+
+<p>Event details</p>
+<ul>
+  <li><strong>IP address:</strong> ${(event.info.ipAddress)!'&mdash;'}</li>
+  <li><strong>City:</strong> ${(event.info.location.city)!'&mdash;'}</li>
+  <li><strong>Country:</strong> ${(event.info.location.country)!'&mdash;'}</li>
+  <li><strong>Zipcode:</strong> ${(event.info.location.zipcode)!'&mdash;'}</li>
+  <li><strong>Lat/long:</strong> ${(event.info.location.latitude)!'&mdash;'}/${(event.info.location.longitude)!'&mdash;'}</li>
+</ul>
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/threat-detected.txt.ftl
+++ b/identity-pre-verification/templates/email/threat-detected.txt.ftl
@@ -1,0 +1,25 @@
+[#setting url_escaping_charset="UTF-8"]
+[#if event.type == "UserLoginSuspicious"]
+A suspicious login was made on your account. If this was you, you can safely ignore this email. If this wasn't you, we recommend that you change your password as soon as possible.
+[#elseif event.type == "UserLoginNewDevice"]
+A login from a new device was detected on your account. If this was you, you can safely ignore this email. If this wasn't you, we recommend that you change your password as soon as possible.
+[#else]
+Suspicious activity has been observed on your account. In order to secure your account, it is recommended to change your password at your earliest convenience.
+[/#if]
+
+Device details
+
+* Device name: ${(event.info.deviceName)!'&mdash;'}
+* Device description: ${(event.info.deviceDescription)!'&mdash;'}
+* Device type: ${(event.info.deviceType)!'&mdash;'}
+* User agent: ${(event.info.userAgent)!'&mdash;'}
+
+Event details
+
+* IP address: ${(event.info.ipAddress)!'-'}
+* City: ${(event.info.location.city)!'-'}
+* Country: ${(event.info.location.country)!'-'}
+* Zipcode: ${(event.info.location.zipcode)!'-'}
+* Lat/long: ${(event.info.location.latitude)!'-'}/${(event.info.location.longitude)!'-'}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-add.html.ftl
+++ b/identity-pre-verification/templates/email/two-factor-add.html.ftl
@@ -1,0 +1,11 @@
+<p>
+ The following two factor method was added to ${user.email}:
+
+  <br>
+  <strong>Method: ${method.method}</strong>
+  <br>
+  <strong>Identifier: ${method.id}</strong>
+
+</p>
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-add.txt.ftl
+++ b/identity-pre-verification/templates/email/two-factor-add.txt.ftl
@@ -1,0 +1,6 @@
+The following two factor method was added to ${user.email}:
+
+- Method: ${method.method}
+- Identifier: ${method.id}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-login.html.ftl
+++ b/identity-pre-verification/templates/email/two-factor-login.html.ftl
@@ -1,0 +1,8 @@
+<p>
+  To complete your login request, enter this one-time code code on the login form when prompted.
+</p>
+<p>
+  <strong>${code}</strong>
+</p>
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-login.txt.ftl
+++ b/identity-pre-verification/templates/email/two-factor-login.txt.ftl
@@ -1,0 +1,5 @@
+To complete your login request, enter this one-time code code on the login form when prompted.
+
+${code}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-remove.html.ftl
+++ b/identity-pre-verification/templates/email/two-factor-remove.html.ftl
@@ -1,0 +1,11 @@
+<p>
+ The following two factor method was removed from ${user.email}:
+
+  <br>
+  <strong>Method: ${method.method}</strong>
+  <br>
+  <strong>Identifier: ${method.id}</strong>
+
+</p>
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/email/two-factor-remove.txt.ftl
+++ b/identity-pre-verification/templates/email/two-factor-remove.txt.ftl
@@ -1,0 +1,6 @@
+The following two factor method was removed from ${user.email}:
+
+- Method: ${method.method}
+- Identifier: ${method.id}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-forgot-password.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-forgot-password.txt.ftl
@@ -1,0 +1,12 @@
+[#setting url_escaping_charset="UTF-8"]
+To change your password click on the following link.
+
+  [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state'.
+       If we have an application context, append the client_id to ensure the correct application theme when applicable.
+  --]
+[#assign url = "http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}" /]
+[#list state!{} as key, value][#if key != "tenantId" && key != "client_id" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+${url}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-passwordless-login.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-passwordless-login.txt.ftl
@@ -1,0 +1,14 @@
+[#setting url_escaping_charset="UTF-8"]
+You have requested to log into FusionAuth using this phone number. If you do not recognize this request please ignore this message.
+
+[#if oneTimeCode??]
+  Login code: ${oneTimeCode}
+[#else]
+[#-- The optional 'state' map provided on the Start Passwordless API call is exposed in the template as 'state' --]
+    [#assign url = "http://localhost:9011/oauth2/passwordless/${code}?tenantId=${user.tenantId}" /]
+    [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+    ${url}
+[/#if]
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-setup-password.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-setup-password.txt.ftl
@@ -1,0 +1,3 @@
+Your account has been created and you must click the following link to set a password.
+
+http://localhost:9011/password/change/${changePasswordId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${user.tenantId}

--- a/identity-pre-verification/templates/message/phone-threat-detected.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-threat-detected.txt.ftl
@@ -1,0 +1,25 @@
+[#setting url_escaping_charset="UTF-8"]
+[#if event.type == "UserLoginSuspicious"]
+A suspicious login was made on your account. If this was you, you can safely ignore this message. If this wasn't you, we recommend that you change your password as soon as possible.
+[#elseif event.type == "UserLoginNewDevice"]
+A login from a new device was detected on your account. If this was you, you can safely ignore this message. If this wasn't you, we recommend that you change your password as soon as possible.
+[#else]
+Suspicious activity has been observed on your account. In order to secure your account, it is recommended to change your password at your earliest convenience.
+[/#if]
+
+Device details
+
+* Device name: ${(event.info.deviceName)!'-'}
+* Device description: ${(event.info.deviceDescription)!'-'}
+* Device type: ${(event.info.deviceType)!'-'}
+* User agent: ${(event.info.userAgent)!'-'}
+
+Event details
+
+* IP address: ${(event.info.ipAddress)!'-'}
+* City: ${(event.info.location.city)!'-'}
+* Country: ${(event.info.location.country)!'-'}
+* Zipcode: ${(event.info.location.zipcode)!'-'}
+* Lat/long: ${(event.info.location.latitude)!'-'}/${(event.info.location.longitude)!'-'}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-two-factor-add.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-two-factor-add.txt.ftl
@@ -1,0 +1,6 @@
+The following two factor method was added to ${user.phoneNumber}:
+
+- Method: ${method.method}
+- Identifier: ${method.id}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-two-factor-login.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-two-factor-login.txt.ftl
@@ -1,0 +1,5 @@
+To complete your login request, enter this one-time code code on the login form when prompted.
+
+${code}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-two-factor-remove.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-two-factor-remove.txt.ftl
@@ -1,0 +1,6 @@
+The following two factor method was removed from ${user.phoneNumber}:
+
+- Method: ${method.method}
+- Identifier: ${method.id}
+
+- FusionAuth Admin

--- a/identity-pre-verification/templates/message/phone-verification.txt.ftl
+++ b/identity-pre-verification/templates/message/phone-verification.txt.ftl
@@ -1,0 +1,12 @@
+[#-- When a one-time code is provided, you will want the user to enter this value interactively using a form. In this workflow the verificationId
+     is not shown to the user and instead the one-time code must be paired with the verificationId which is usually in a hidden form field. When the two
+     values are presented together, the phone number can be verified --]
+[#if verificationOneTimeCode??]
+Verification code: ${verificationOneTimeCode}
+[#else]
+To complete your phone number verification click on the following link.
+
+http://localhost:9011/phone/verify/${verificationId}?client_id=${(application.oauthConfiguration.clientId)!''}&tenantId=${tenant.id}
+[/#if]
+
+- FusionAuth Admin


### PR DESCRIPTION
This pull request adds a full identity pre-verification setup example. With a set of email and messaging templates, tenant email identity configuration, form fields, advanced registration form and a pre-configured application with related test users.